### PR TITLE
Added block control in send_batch

### DIFF
--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -237,6 +237,7 @@ La librería está creada con diferentes clases dependiendo de la funcionalidad 
         - :param opcional `post_retry_backoff_factor`: Factor que se usa, para esperar varios segundos tras enviar una ráfaga de datos. (default: 0)
         - :param opcional `sleep_send_batch`: Pausa en segundos, que se realiza cada vez que se envia una ráfaga de datos. (default: 0). 
         - :param opcional `cb_flowcontrol`: Opción del Context Broker, que permite un mejor rendimiento en caso de envío masivo de datos (batch updates). Este mecanismo, requiere arrancar el Context Broker con un flag concreto y en las peticiones de envío de datos, añadir esa opción. Referencia en [documentación de Orion](https://fiware-orion.readthedocs.io/en/master/admin/perf_tuning/index.html#updates-flow-control-mechanism) (default: False)
+        - :param opcional `block_size`: Cuando se realiza el envío de datos al Context Broker mediante la función de `send_batch`, se realiza envíos en tramos que no excedan el block_size indicado (default: 800000). Se permite modificar el valor de block_size, pero sin superar la limitación de 800000. En caso de indicar un valor que supere ese límite, se lanzará una excepción ValueError indicando que se ha excedido el límite del valor permitido.
         - :raises [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError): Se lanza cuando le falta alguno de los argumentos obligatorios
     - `send_batch`: Función que envía un lote de entidades al Context Broker. Se le pasa el authManager, que ya dispone de un listado con todos los tokens por subservicio y usa el correspondiente para realizar la llamada al Context Broker. Si no se dispone de token o ha caducado, se solicita nuevo y luego envía los datos.
         - :param obligatorio `auth`: Se le proporciona el authManager, que tiene las credenciales por si ha de solicitar un token y dispone del listado de tokens asociado. Si no se define en la llamada a la función, avisará con una excepción ValueError.
@@ -264,7 +265,7 @@ La librería está creada con diferentes clases dependiendo de la funcionalidad 
           "JSON Entity Representation" de la [NGSIv2 API](https://fiware.github.io/specifications/ngsiv2/stable/)
     
 ## Changelog
-
+- Update: send_batch function with block control (limitation cb)
 - Add: more filters (q, mq, georel, geometry, coords, id) to get_entities_page function ([#13](https://github.com/telefonicasc/etl-framework/issues/13))
 
 0.1.0 (April 26th, 2022)

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -265,7 +265,7 @@ La librería está creada con diferentes clases dependiendo de la funcionalidad 
           "JSON Entity Representation" de la [NGSIv2 API](https://fiware.github.io/specifications/ngsiv2/stable/)
     
 ## Changelog
-- Update: send_batch function with block control (limitation cb)
+- Update: send_batch function with block control to overcome CB limitation (new cbManager constructor optional param block_size) ([#6](https://github.com/telefonicasc/etl-framework/issues/6))
 - Add: more filters (q, mq, georel, geometry, coords, id) to get_entities_page function ([#13](https://github.com/telefonicasc/etl-framework/issues/13))
 
 0.1.0 (April 26th, 2022)

--- a/python-lib/tc_etl_lib/tc_etl_lib/cb.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/cb.py
@@ -76,7 +76,7 @@ class cbManager:
     # and it is not recommended to change it
     block_size = 800000
     
-    def __init__(self,*, endpoint: str = None, timeout: int = 10, post_retry_connect: int = 3, post_retry_backoff_factor: int = 20, sleep_send_batch: int = 0, cb_flowcontrol: bool = False) -> None:
+    def __init__(self,*, endpoint: str = None, timeout: int = 10, post_retry_connect: int = 3, post_retry_backoff_factor: int = 20, sleep_send_batch: int = 0, cb_flowcontrol: bool = False, block_size: int = 800000) -> None:
         
         if (endpoint == None):
             raise ValueError(f'You must define <<endpoint>> in cbManager')
@@ -87,6 +87,12 @@ class cbManager:
         self.post_retry_backoff_factor = post_retry_backoff_factor
         self.sleep_send_batch = sleep_send_batch
         self.cb_flowcontrol = cb_flowcontrol 
+        
+        # check block_size limit.
+        if (int(block_size) > int(800000)):
+            raise ValueError('Block size limit reached! <<block_size>> value cannot be greater than 800000')
+        
+        self.block_size = block_size
 
     def get_entities_page(self, *, subservice: str = None, auth: authManager = None, offset: int = None, limit: int = None, type: str = None, orderBy: str = None, q: str = None, mq: str = None, georel: str = None, geometry: str = None, coords: str = None, id: str = None):
         """Retrieve data from context broker


### PR DESCRIPTION
Reference: https://github.com/telefonicasc/etl-framework/issues/6

Se ha añadido un control de bloques, acorde a la limitación del CB, cuando se realiza una operación de send_batch. De se puede enviar todas las entidades que se necesiten e intermante se controla que se envíen en bloques de 800k como máximo.

A nivel de compatibilidad hacia atrás, es completamente transparente. No implica modificación en los send_bactch de versiones anteriores.