### PR TITLE
Added support for stores

### DIFF
--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -368,6 +368,8 @@ with new_store() as store:
 
 ## Changelog
 
+- Add: new stores for saving entity batches, `orionStore` and `sqlFileStore` ([#46](https://github.com/telefonicasc/etl-framework/pull/46))
+
 0.6.0 (December 15th, 2022)
 
 - Add: new optional parameter called `batch_size` in cbManager constructor ([#37](https://github.com/telefonicasc/etl-framework/issues/37))

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -336,8 +336,8 @@ La librería además proporciona [context managers](https://docs.python.org/3/re
     - :param: `schema` opcional: Nombre del schema a utilizar en los INSERT. Por defecto es `":target_schema"`, por lo que es al ejecutar el comando `psql` cuando se debe especificar con `-v target_schema=...`. Pero se le puede dar aquí un valor explícito.
     - :param: `namespace` opcional: Prefijo opcional para los nombres de tabla generados a partir del entityType. Si se especifica, el nombre de tabla se construye como `f"{namespace}_{entitytType.lower()}"`
     - :param: `table_names` opcional: mapeo de nombre de entidad a nombre de tabla. Permite especificar nombres de tabla por entidad distintos a los por defecto.
-        - si `table_name[entityType]` existe y es un string != "", se usa como nombre de tabla para el tipo de entidad.
-        - si `table_name[entityType]` no existe, se usa el nombre de tabla por defecto (f"{entitytType.lower()}" o f"{namespace}_{entitytType.lower()}")
+        - si `table_name[entityType]` existe y es un string `!= ""`, se usa como nombre de tabla para el tipo de entidad.
+        - si `table_name[entityType]` no existe, se usa el nombre de tabla por defecto (`f"{entitytType.lower()}"` o `f"{namespace}_{entitytType.lower()}"`)
         - si `table_name[entityType]` existe y es *falsy* (`None`, `""`, etc), las entidades de ese tipo no se escriben al fichero SQL.
     - :param: `chunk_size` opcional: máximo número de líneas a incluir en un solo `INSERT`. Default=10000
     - :param: `append` opcional: en caso de que el fichero exista, `append=True` añade los INSERT mientras que `append=False` sobrescribe el fichero. Default False.

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -213,6 +213,13 @@ entities = [
  
 cbm.send_batch(auth=auth, subservice='/energia', entities=entities)
 
+# O, usando un store orion
+with tc.orionStore(cb=cbm, auth=auth, subservice='/energia') as store:
+    store(entities)
+
+# O un store sqlFile
+with tc.sqlFileStore(path="inserts.sql", subservice="/energia", namespace="energy") as store:
+    store(entities)
 ```
 
 ## Funciones disponibles en la librería
@@ -317,7 +324,48 @@ La librería está creada con diferentes clases dependiendo de la funcionalidad 
         - :param opcional `options_send`: Lista de opciones que recibe el Context Broker cuando va a eliminar las entidades. Se pueden ver las opciones disponibles en [API NGSIv2 de Orion](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#update-post-v2opupdate). En el caso de que la opcion `flowControl` se especifique dentro de este parámetro, un `cb_flowcontrol` (en la inicializción de cbManager) a `False` se ignora, quedanco como si `cb_flowcontrol` se hubiese establecido a `True`.
         - :raises [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError): Se lanza cuando le falta algún argumento o inicializar alguna varibale del objeto cbManager, para poder realizar la autenticación o envío de datos.
         - :raises FetchError: Se lanza cuando el servicio de Context Broker, responde con un error concreto.
-    
+
+La librería además proporciona [context managers](https://docs.python.org/3/reference/datamodel.html#context-managers) para abstraer la escritura de entidades en formato NGSIv2 a distintos backends (`store`s). Estos son:
+
+- `orionStore`: Genera un store asociado a una instancia particular de `cbManager` y `authManager`. Todas las entidades que se envíen a este store, se almacenarán en el cbManager correspondiente.
+    - todos los parámetros son idénticos a los de la función send_batch de la clase cbManager.
+    - :return: un `callable` que recibe una lista de entidades y las envía a la función `send_batch` del `cb` especificado. Como tal, puede lanzar cualquiera de las excepciones que lanza la función `send_batch` de la clase `cbManager`.
+
+- `sqlFileStore`: Genera un store asociado a un fichero local. Todas las entidades que se envíen a este store se almacenarán como órdenes SQL `INSERT` en el fichero local. Además de los atributos de la entidad, cada `INSERT` añadirá las columnas `fiwareservicepath` y `recvtime` para ser consistente con el formato típico de tabla histórica de entidad, y no dar error de inserción (ya que esas columnas suelen ser NOT NULL).
+    - :param: `subservice`: Nombre de subservicio a escribir en la columna `fiwareservicepath`
+    - :param: `schema` opcional: Nombre del schema a utilizar en los INSERT. Por defecto es `":target_schema"`, por lo que es al ejecutar el comando `psql` cuando se debe especificar con `-v target_schema=...`. Pero se le puede dar aquí un valor explícito.
+    - :param: `namespace` opcional: Prefijo opcional para los nombres de tabla generados a partir del entityType. Si se especifica, el nombre de tabla se construye como `f"{namespace}_{entitytType.lower()}"`
+    - :param: `table_names` opcional: mapeo de nombre de entidad a nombre de tabla. Permite especificar nombres de tabla por entidad distintos a los por defecto.
+        - si `table_name[entityType]` existe y es un string != "", se usa como nombre de tabla para el tipo de entidad.
+        - si `table_name[entityType]` no existe, se usa el nombre de tabla por defecto (f"{entitytType.lower()}" o f"{namespace}_{entitytType.lower()}")
+        - si `table_name[entityType]` existe y es *falsy* (`None`, `""`, etc), las entidades de ese tipo no se escriben al fichero SQL.
+    - :param: `chunk_size` opcional: máximo número de líneas a incluir en un solo `INSERT`. Default=10000
+    - :param: `append` opcional: en caso de que el fichero exista, `append=True` añade los INSERT mientras que `append=False` sobrescribe el fichero. Default False.
+    - :return: un `callable` que recibe una lista de entidades y las escribe como instrucciones sql `INSERT` en el fichero especificado.
+
+El modo de uso de cualquiera de los context managers es idéntico:
+
+```python
+# En primer lugar, se selecciona el store en función del criterio que convenga.
+# por ejemplo, en este caso, una variable `use_file_store`
+if use_file_store == True:
+    new_store = lambda: tc.sqlFileStore(
+        path=Path("my_file_name.sql"),
+        subservice="/my_subservice"
+    )
+else:
+    new_store = lambda: tc.orionStore(
+        cb=my_cb,
+        auth=my_auth,
+        subservice="/my_subservice"
+    )
+
+# A partir de aqui, el código sería independiente del tipo de store usado
+with new_store() as store:
+    entities = ...
+    store(entities)
+```
+
 ## Changelog
 
 0.6.0 (December 15th, 2022)

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -37,7 +37,8 @@ LONG_DESC_TYPE = "text/markdown"
 #Paquetes necesarios para que funcione la librería. Se instalarán a la vez si no lo tuvieras ya instalado
 INSTALL_REQUIRES = [
     'requests==2.21.0',
-    'urllib3==1.24.1'
+    'urllib3==1.24.1',
+    'psycopg2-binary>=2.9.5'
 ]
 
 setup(

--- a/python-lib/tc_etl_lib/tc_etl_lib/__init__.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/__init__.py
@@ -21,4 +21,4 @@
 
 from .auth import *
 from .cb import *
-from .store import orionStore, sqlFileStore
+from .store import Store, orionStore, sqlFileStore

--- a/python-lib/tc_etl_lib/tc_etl_lib/__init__.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/__init__.py
@@ -21,3 +21,4 @@
 
 from .auth import *
 from .cb import *
+from .store import orionStore, sqlFileStore

--- a/python-lib/tc_etl_lib/tc_etl_lib/cb.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/cb.py
@@ -68,7 +68,7 @@ class cbManager:
     sleep_send_batch: sleep X seconds afters send update batch. (default: 0). 
     cb_flowcontrol: Opción del Context Broker, que permite un mejor rendimiento en caso de envío masivo de datos (batch updates). Este mecanismo, requiere arrancar el Context Broker con un flag concreto y en las peticiones de envío de datos, añadir esa opción. Referencia en Fiware Orion Docs (default: False)
     block_size: maximum size per batch, in bytes. Default is 800kb and it is not recommended to change.
-    batch_size: maximum size per batch, in entites. Default is 0 (no limitiation, other than block_size).
+    batch_size: maximum size per batch, in entities. Default is 0 (no limitiation, other than block_size).
     """
     
     endpoint: str

--- a/python-lib/tc_etl_lib/tc_etl_lib/store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/store.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+#
+# This file is part of tc_etl_lib
+#
+# tc_etl_lib is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# tc_etl_lib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with IoT orchestrator. If not, see http://www.gnu.org/licenses/.
+
+'''
+Store API for generic storage of entities
+  - orionStore: saves batches to Orion environment
+  - sqlFileStore: saves batches to SQL File
+'''
+from typing import Callable, Dict, List, Any, Iterable, Sequence, Optional
+from contextlib import contextmanager
+from pathlib import Path
+from collections import defaultdict
+import json
+import itertools
+from .cb import cbManager
+from .auth import authManager
+import psycopg2
+
+
+# A Store is a callable where you can save batches of entities.
+Store = Callable[[List[Any]], None]
+
+@contextmanager
+def orionStore(cb: cbManager, auth: authManager, *, service:str=None, subservice:str=None, actionType:str='append', options:list=[]):
+    '''
+    Context manager that creates a store to save entities to the given cbManager
+    All parameters are the same as for the cbManager.send_batch function
+    '''
+    def send_batch(entities: List[Any]):
+        cb.send_batch(service=service, subservice=subservice, auth=auth, actionType=actionType, options=options, entities=entities)
+    yield send_batch
+
+@contextmanager
+def sqlFileStore(path: Path, *, subservice:str, schema:str=":target_schema", namespace:str="", table_names:Optional[Dict[str, str]]=None, chunk_size:int=10000, append:bool=False):
+    '''
+    Context manager that creates a store to save entities to an SQL File.
+    SQL syntax used is postgresql.
+
+    subservice: name of the orion subservice
+    schema: name of the schema. Defaults to `:target_schema` (a psql variable)
+    namespace: optional prefix for all tables. Table name for each entity type defaults to "namespace_entityType"
+    table_names: dict to override default table names.
+      - if table_name[entityType] exists and is not empty, it is used as table name for the entity type.
+      - if table_name[entityType] does not exist, the default table name (namespace_entityType) is used.
+      - if table_name[entityType] exists and is empty, entities with the given type are not saved.
+    chunk_size: maximum lines in a single insert statement. Default=10000
+    append: append to the file instead of overwriting.
+    '''
+    mode = "a+" if append else "w+"
+    handler = path.open(mode=mode, encoding="utf-8")
+    some_table_names = table_names or {} # make sure it is not None
+    try:
+        def send_batch(entities: List[Any]):
+            for chunk in iter_chunk(entities, chunk_size):
+                handler.write(sqlfile_batch(schema=schema, namespace=namespace, table_names=some_table_names, subservice=subservice, entities=chunk))
+                handler.write("\n")
+        yield send_batch
+    finally:
+        handler.close()
+
+
+def iter_chunk(iterable, chunk_size: int):
+    '''
+    Chunks an iterable into smaller iterables.
+    
+    chunk_size: size of the smaller chunks
+    '''
+    # See https://stackoverflow.com/questions/8991506/iterate-an-iterator-by-chunks-of-n-in-python
+    it = iter(iterable)
+    while True:
+        chunk_it = itertools.islice(it, chunk_size)
+        try:
+            first_el = next(chunk_it)
+        except StopIteration:
+            return
+        yield itertools.chain((first_el,), chunk_it)
+
+def sql_escape(obj: Any) -> str:
+    '''Escapes a value to be used in a SQL string'''
+    # See https://github.com/psycopg/psycopg2/issues/331
+    adaptor = psycopg2.extensions.adapt(obj)
+    if hasattr(adaptor, 'encoding'):
+        adaptor.encoding = 'utf-8'
+    return adaptor.getquoted().decode('utf-8')
+
+def sqlfile_values(subservice: str, entity: Dict[str, Any], fields: Iterable[str]) -> str:
+    '''
+    Generates a string suitable for SQL insert, with all values of the entity
+    
+    subservice: subservice name
+    entity: ngsi entity
+    fields: list of fields to save in the entity (omitting id, type)'''
+    sql = [
+        sql_escape(entity['id']),
+        sql_escape(entity['type']),
+        sql_escape(subservice),
+        "NOW()"
+    ]
+    for field in fields:
+        entry = entity.get(field, {'type':'Text', 'value': None})
+        value_untyped = entry.get('value', None)
+        value: str
+        if value_untyped is None:
+            value = "NULL"
+        elif 'json' in entry['type']:
+            value = sql_escape(json.dumps(value_untyped))
+            if 'geo' in entry['type']:
+                value = f"ST_GeomFromGeoJSON({value})"
+        else:
+            value = sql_escape(value_untyped)
+        sql.append(value)
+    return f"({','.join(sql)})"
+
+def sqlfile_insert(subservice: str, table_name: str, fields: Sequence[str], entities: Iterable[Any]) -> str:
+    '''
+    Generate SQL INSERT lines from sequence of entities
+    
+    subservice: subservice name
+    table_name: SQL table name to use
+    fields: sequence of attribute names
+    entities: iterable of entities
+    '''
+    return "\n".join((
+        f"INSERT INTO {table_name} (entityid,entitytype,fiwareservicepath,recvtime,{','.join(fields)}) VALUES",
+        ",\n".join(
+            sqlfile_values(subservice, entity, fields)
+            for entity in entities
+        ) + ";"
+    ))
+
+def sql_table_name(schema: str, namespace: str, entity_type: str, table_names: Dict[str, str]) -> str:
+    '''
+    Generates table_name from namespace and entity_type
+    
+    namespace: namespace to use to prefix entityType
+    entity_type: type of entity
+    table_names: overrides default names for any entityType
+    '''
+    default_name = ((namespace + "_") if namespace != "" else "") + entity_type.lower()
+    mapped_name  = table_names.get(entity_type, default_name)
+    if not mapped_name: # Tables mapped to empty string or None are not saved to SQL
+        return ""
+    # Tables mapped to some name are prefixed with schema name
+    return f"{schema}.{mapped_name}"
+
+def sqlfile_batch(schema: str, namespace: str, table_names: Dict[str, str], subservice: str, entities: Iterable[Any]) -> str:
+    '''
+    Generate a single SQL insert batch statement
+
+    schema: schema name
+    namespace: namespace for table names
+    table_names: overrides entytyType to table name defaults
+    subservice: subservice name
+    entities: Iterable of entities
+    '''
+    # Group entities by type
+    entities_by_type = defaultdict(list)
+    for entity in entities:
+        entities_by_type[entity['type']].append(entity)
+    # For each type, get the fieldset
+    fields_by_type = defaultdict(set)
+    for entity_type, typed_entities in entities_by_type.items():
+        for entity in typed_entities:
+            for field in entity:
+                if field not in ('id', 'type'):
+                    fields_by_type[entity_type].add(field)
+    # Generate all rows for each type
+    sql = []
+    for entity_type, typed_entities in sorted(entities_by_type.items()):
+        table_name = sql_table_name(schema, namespace, entity_type, table_names)
+        if table_name:
+            table_cols = sorted(fields_by_type[entity_type])
+            sql.append(sqlfile_insert(subservice, table_name, table_cols, typed_entities))
+    # and return SQL insert code
+    return "\n".join(sql)

--- a/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
@@ -104,7 +104,7 @@ class TestSQLFileStore(unittest.TestCase):
         '''test sqlFileStore with given parameters and expectations'''
         with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8', delete=False) as tmpFile:
             try:
-                tmpFile.close()
+                tmpFile.close() # we only want the name, not the handle
                 if append_text != "":
                     with open(tmpFile.name, "w+", encoding="utf-8") as outfile:
                         outfile.write(dedent(append_text))

--- a/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
@@ -194,7 +194,7 @@ class TestSQLFileStore(unittest.TestCase):
         self.do_test(expected, "", subservice="/testsrv", chunk_size=3)
 
     def test_append(self):
-        '''Test SQL File splitting batches in smaller chunks'''
+        '''Test SQL File append to existing data'''
         create = """
         CREATE TABLE IF NOT EXISTS myschema.type_a (entityid text, entitytype text, fiwareservicepath text, recvtime timestamp with time zone not null, location geometry, municipality text);
         CREATE TABLE IF NOT EXISTS myschema.type_b (entityid text, entitytype text, fiwareservicepath text, recvtime timestamp with time zone not null, timeinstant timestamp with time zone not null, temperature doule precision);

--- a/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Telefónica Soluciones de Informática y Comunicaciones de España, S.A.U.
+#
+# This file is part of tc_etl_lib
+#
+# tc_etl_lib is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# tc_etl_lib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with IoT orchestrator. If not, see http://www.gnu.org/licenses/.
+
+'''
+SQLFile Store tests
+'''
+
+import unittest
+import textwrap
+import os
+import tempfile
+from pathlib import Path
+from .store import sqlFileStore
+
+TestEntities = [
+    {
+        "id": "id_1",
+        "type": "type_A",
+        "municipality": {
+            "type": "Text",
+            "value": "NA"
+        },
+        "location": {
+            "type": "geo:json",
+            "value": { "type": "Point", "coordinates": [1, 2] }
+        }
+    },
+    {
+        "id": "id_2",
+        "type": "type_B",
+        "TimeInstant": {
+            "type": "DateTime",
+            "value": "2022-12-15T18:00:00Z"
+        },
+        "temperature": {
+            "type": "Number",
+            "value": 20
+        }
+    },
+    {
+        "id": "id_3",
+        "type": "type_A",
+        "municipality": {
+            "type": "Text",
+            "value": "NA"
+        },
+        "location": {
+            "type": "geo:json",
+            "value": { "type": "Point", "coordinates": [3, 4] }
+        }
+    },
+    {
+        "id": "id_4",
+        "type": "type_B",
+        "TimeInstant": {
+            "type": "DateTime",
+            "value": "2022-12-15T18:01:00Z"
+        },
+        "temperature": {
+            "type": "Number",
+            "value": 21
+        }
+    },
+    {
+        "id": "id_5",
+        "type": "type_A",
+        "municipality": {
+            "type": "Text",
+            "value": "Alcobendas"
+        },
+        "location": {
+            "type": "geo:json",
+            "value": { "type": "Point", "coordinates": [5, 6] }
+        }
+    },
+]
+
+
+def dedent(text: str) -> str:
+    '''Remove leading whitespace'''
+    return textwrap.dedent(text.strip("\n"))
+
+class TestSQLFileStore(unittest.TestCase):
+    '''Tests for sqlFileStore'''
+
+    def do_test(self, expect: str, append_text: str, **params):
+        '''test sqlFileStore with given parameters and expectations'''
+        with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8', delete=False) as tmpFile:
+            try:
+                tmpFile.close()
+                if append_text != "":
+                    with open(tmpFile.name, "w+", encoding="utf-8") as outfile:
+                        outfile.write(dedent(append_text))
+                with sqlFileStore(Path(tmpFile.name), **params) as store:
+                    store(TestEntities)
+                with open(tmpFile.name, "r", encoding="utf-8") as infile:
+                    data = infile.read()
+                    self.maxDiff = None
+                    self.assertEqual(dedent(data).strip(), dedent(expect).strip())
+            finally:
+                os.unlink(tmpFile.name)
+
+    def test_default_tables(self):
+        '''Test SQL File using standard table names'''
+        expected = """
+        INSERT INTO :target_schema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_1','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA'),
+        ('id_3','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [3, 4]}'),'NA'),
+        ('id_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [5, 6]}'),'Alcobendas');
+        INSERT INTO :target_schema.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20),
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, "", subservice="/testsrv", chunk_size=5)
+
+    def test_schema_tables(self):
+        '''Test SQL File using standard table names and custom schema'''
+        expected = """
+        INSERT INTO schema1.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_1','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA'),
+        ('id_3','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [3, 4]}'),'NA'),
+        ('id_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [5, 6]}'),'Alcobendas');
+        INSERT INTO schema1.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20),
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, "", subservice="/testsrv", schema="schema1", chunk_size=5)
+
+    def test_namespaced_tables(self):
+        '''Test SQL File using namespaced names'''
+        expected = """
+        INSERT INTO :target_schema.ns_type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_1','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA'),
+        ('id_3','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [3, 4]}'),'NA'),
+        ('id_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [5, 6]}'),'Alcobendas');
+        INSERT INTO :target_schema.ns_type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20),
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, "", namespace="ns", subservice="/testsrv")
+
+    def test_rename_entity(self):
+        '''Test SQL File overriding some entity tables'''
+        expected = """
+        INSERT INTO :target_schema.renamed (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_1','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA'),
+        ('id_3','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [3, 4]}'),'NA'),
+        ('id_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [5, 6]}'),'Alcobendas');
+        INSERT INTO :target_schema.ns_type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20),
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, "", subservice="/testsrv", namespace="ns", table_names={'type_A': 'renamed'})
+
+    def test_skip_entity(self):
+        '''Test SQL File skipping some entity types'''
+        expected = """
+        INSERT INTO :target_schema.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20),
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, "", subservice="/testsrv", table_names={'type_A': None})
+
+    def test_small_chunks(self):
+        '''Test SQL File splitting batches in smaller chunks'''
+        expected = """
+        INSERT INTO :target_schema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_1','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA'),
+        ('id_3','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [3, 4]}'),'NA');
+        INSERT INTO :target_schema.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20);
+        INSERT INTO :target_schema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [5, 6]}'),'Alcobendas');
+        INSERT INTO :target_schema.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, "", subservice="/testsrv", chunk_size=3)
+
+    def test_append(self):
+        '''Test SQL File splitting batches in smaller chunks'''
+        create = """
+        CREATE TABLE IF NOT EXISTS myschema.type_a (entityid text, entitytype text, fiwareservicepath text, recvtime timestamp with time zone not null, location geometry, municipality text);
+        CREATE TABLE IF NOT EXISTS myschema.type_b (entityid text, entitytype text, fiwareservicepath text, recvtime timestamp with time zone not null, timeinstant timestamp with time zone not null, temperature doule precision);
+        """
+        expected = """
+        CREATE TABLE IF NOT EXISTS myschema.type_a (entityid text, entitytype text, fiwareservicepath text, recvtime timestamp with time zone not null, location geometry, municipality text);
+        CREATE TABLE IF NOT EXISTS myschema.type_b (entityid text, entitytype text, fiwareservicepath text, recvtime timestamp with time zone not null, timeinstant timestamp with time zone not null, temperature doule precision);
+        INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_1','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA'),
+        ('id_3','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [3, 4]}'),'NA');
+        INSERT INTO myschema.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_2','type_B','/testsrv',NOW(),'2022-12-15T18:00:00Z',20);
+        INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality) VALUES
+        ('id_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [5, 6]}'),'Alcobendas');
+        INSERT INTO myschema.type_b (entityid,entitytype,fiwareservicepath,recvtime,TimeInstant,temperature) VALUES
+        ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
+        """
+        self.do_test(expected, create, subservice="/testsrv", schema="myschema", chunk_size=3, append=True)


### PR DESCRIPTION
Importa en la librería el mecanismo de `stores` que estamos usando en varias ETLs:

- Propone una interfaz común `Store` para almacenar entidades NGSIv2 en backends genéricos. La interfaz consiste en un solo método con un solo parámetro, `entities`.
- Implementa dos `Store`s ajustados a la interfaz:
  - `orionStore` que escribe las entidades a un `cbManager` con `send_batch`
  - `sqlFileStore` que escribe las entidades a un fichero SQL. Añade una dependencia a la librería `psycopg2-binary`

