### PR TITLE
added replace_id attrib to sqlFileStore

### DIFF
--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -341,6 +341,7 @@ La librería además proporciona [context managers](https://docs.python.org/3/re
         - si `table_name[entityType]` existe y es *falsy* (`None`, `""`, etc), las entidades de ese tipo no se escriben al fichero SQL.
     - :param: `chunk_size` opcional: máximo número de líneas a incluir en un solo `INSERT`. Default=10000
     - :param: `append` opcional: en caso de que el fichero exista, `append=True` añade los INSERT mientras que `append=False` sobrescribe el fichero. Default False.
+    - :param `replace_id` opcional: reemplaza el ID de la entidad por un valor construido a partir de la lista de atributos indicados en este parámetro, separados por `_`. Imita el comportamiento del atributo `replaceId` de los flujos histórico y lastdata de URBO-DEPLOYER, para poder usar este *store* en ETLs que alimenten *singletons*.
     - :return: un `callable` que recibe una lista de entidades y las escribe como instrucciones sql `INSERT` en el fichero especificado.
 
 El modo de uso de cualquiera de los context managers es idéntico:

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -341,7 +341,9 @@ La librería además proporciona [context managers](https://docs.python.org/3/re
         - si `table_name[entityType]` existe y es *falsy* (`None`, `""`, etc), las entidades de ese tipo no se escriben al fichero SQL.
     - :param: `chunk_size` opcional: máximo número de líneas a incluir en un solo `INSERT`. Default=10000
     - :param: `append` opcional: en caso de que el fichero exista, `append=True` añade los INSERT mientras que `append=False` sobrescribe el fichero. Default False.
-    - :param `replace_id` opcional: reemplaza el ID de la entidad por un valor construido a partir de la lista de atributos indicados en este parámetro, separados por `_`. Imita el comportamiento del atributo `replaceId` de los flujos histórico y lastdata de URBO-DEPLOYER, para poder usar este *store* en ETLs que alimenten *singletons*.
+    - :param `replace_id` opcional: diccionario `tipo de entidad` => `lista de atributos replace_id`.
+        Reemplaza el ID de las entidades del tipo o tipos especificados, por un valor construido a partir de la lista de atributos indicados en este parámetro, separados por `_`.
+        Imita el comportamiento del atributo `replaceId` de los flujos históricos de URBO-DEPLOYER, para poder usar este *store* en ETLs que alimenten *singletons*.
     - :return: un `callable` que recibe una lista de entidades y las escribe como instrucciones sql `INSERT` en el fichero especificado.
 
 El modo de uso de cualquiera de los context managers es idéntico:

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -442,6 +442,8 @@ TOTAL                        403    221    45%
 
 ## Changelog
 
+- Add: new optional parameter called `replace_id` in sqlFileStore context manager ([#58](https://github.com/telefonicasc/etl-framework/pull/58))
+
 0.7.0 (December 233rd, 2022)
 
 - Add: new stores for saving entity batches, `orionStore` and `sqlFileStore` ([#46](https://github.com/telefonicasc/etl-framework/pull/46))

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -343,7 +343,7 @@ La librería además proporciona [context managers](https://docs.python.org/3/re
     - :param: `append` opcional: en caso de que el fichero exista, `append=True` añade los INSERT mientras que `append=False` sobrescribe el fichero. Default False.
     - :param `replace_id` opcional: diccionario `tipo de entidad` => `lista de atributos replace_id`.
         Reemplaza el ID de las entidades del tipo o tipos especificados, por un valor construido a partir de la lista de atributos indicados en este parámetro, separados por `_`.
-        Imita el comportamiento del atributo `replaceId` de los flujos históricos de URBO-DEPLOYER, para poder usar este *store* en ETLs que alimenten *singletons*.
+        Imita el comportamiento del atributo `replaceId` de los FLOW_HISTORIC de URBO DEPLOYER, para poder usar este *store* en ETLs que alimenten *singletons*.
     - :return: un `callable` que recibe una lista de entidades y las escribe como instrucciones sql `INSERT` en el fichero especificado.
 
 El modo de uso de cualquiera de los context managers es idéntico:

--- a/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
@@ -100,7 +100,7 @@ def dedent(text: str) -> str:
 class TestSQLFileStore(unittest.TestCase):
     '''Tests for sqlFileStore'''
 
-    def do_test(self, expect: str, append_text: str, **params):
+    def do_test(self, expect: str, append_text: str, entities=TestEntities, **params):
         '''test sqlFileStore with given parameters and expectations'''
         with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8', delete=False) as tmpFile:
             try:
@@ -109,7 +109,7 @@ class TestSQLFileStore(unittest.TestCase):
                     with open(tmpFile.name, "w+", encoding="utf-8") as outfile:
                         outfile.write(dedent(append_text))
                 with sqlFileStore(Path(tmpFile.name), **params) as store:
-                    store(TestEntities)
+                    store(entities)
                 with open(tmpFile.name, "r", encoding="utf-8") as infile:
                     data = infile.read()
                     self.maxDiff = None
@@ -213,3 +213,85 @@ class TestSQLFileStore(unittest.TestCase):
         ('id_4','type_B','/testsrv',NOW(),'2022-12-15T18:01:00Z',21);
         """
         self.do_test(expected, create, subservice="/testsrv", schema="myschema", chunk_size=3, append=True)
+
+    def test_singleton_one_id(self):
+        '''Test replace_id with a single attribute'''
+        entities  = [
+            {
+                "id": "id_singleton",
+                "type": "type_A",
+                "ref": {
+                    "type": "Text",
+                    "value": "id_A"
+                },
+                "municipality": {
+                    "type": "Text",
+                    "value": "NA"
+                },
+                "location": {
+                    "type": "geo:json",
+                    "value": { "type": "Point", "coordinates": [1, 2] }
+                }
+            }
+        ]
+        expected = """
+        INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,ref) VALUES
+        ('id_A','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA','id_A');
+        """
+        self.do_test(expected, "", entities=entities, replace_id=['ref'], subservice="/testsrv", schema="myschema")
+
+    def test_singleton_two_ids(self):
+        '''Test replace_id with two attributes'''
+        entities  = [
+            {
+                "id": "id_singleton",
+                "type": "type_A",
+                "primary": {
+                    "type": "Text",
+                    "value": "id_primary"
+                },
+                "secondary": {
+                    "type": "Number",
+                    "value": 5
+                },
+                "municipality": {
+                    "type": "Text",
+                    "value": "NA"
+                },
+                "location": {
+                    "type": "geo:json",
+                    "value": { "type": "Point", "coordinates": [1, 2] }
+                }
+            }
+        ]
+        expected = """
+        INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,primary,secondary) VALUES
+        ('id_primary_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA','id_primary',5);
+        """
+        self.do_test(expected, "", entities=entities, replace_id=['primary', 'secondary'], subservice="/testsrv", schema="myschema")
+
+    def test_singleton_original_id(self):
+        '''Test replace_id with two attributes'''
+        entities  = [
+            {
+                "id": "id_singleton",
+                "type": "type_A",
+                "ref": {
+                    "type": "Number",
+                    "value": 5
+                },
+                "municipality": {
+                    "type": "Text",
+                    "value": "NA"
+                },
+                "location": {
+                    "type": "geo:json",
+                    "value": { "type": "Point", "coordinates": [1, 2] }
+                }
+            }
+        ]
+        expected = """
+        INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,ref) VALUES
+        ('id_singleton_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA',5);
+        """
+        self.do_test(expected, "", entities=entities, replace_id=['id', 'ref'], subservice="/testsrv", schema="myschema")

--- a/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/test_store.py
@@ -232,13 +232,31 @@ class TestSQLFileStore(unittest.TestCase):
                     "type": "geo:json",
                     "value": { "type": "Point", "coordinates": [1, 2] }
                 }
+            },
+            {
+                "id": "id_no_singleton",
+                "type": "type_B",
+                "ref": {
+                    "type": "Text",
+                    "value": "id_B"
+                },
+                "municipality": {
+                    "type": "Text",
+                    "value": "NA"
+                },
+                "location": {
+                    "type": "geo:json",
+                    "value": { "type": "Point", "coordinates": [1, 2] }
+                }
             }
         ]
         expected = """
         INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,ref) VALUES
         ('id_A','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA','id_A');
+        INSERT INTO myschema.type_b (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,ref) VALUES
+        ('id_no_singleton','type_B','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA','id_B');
         """
-        self.do_test(expected, "", entities=entities, replace_id=['ref'], subservice="/testsrv", schema="myschema")
+        self.do_test(expected, "", entities=entities, replace_id={'type_A':['ref']}, subservice="/testsrv", schema="myschema")
 
     def test_singleton_two_ids(self):
         '''Test replace_id with two attributes'''
@@ -268,10 +286,10 @@ class TestSQLFileStore(unittest.TestCase):
         INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,primary,secondary) VALUES
         ('id_primary_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA','id_primary',5);
         """
-        self.do_test(expected, "", entities=entities, replace_id=['primary', 'secondary'], subservice="/testsrv", schema="myschema")
+        self.do_test(expected, "", entities=entities, replace_id={'type_A':['primary', 'secondary']}, subservice="/testsrv", schema="myschema")
 
     def test_singleton_original_id(self):
-        '''Test replace_id with two attributes'''
+        '''Test replace_id with the original id, plus some attrib'''
         entities  = [
             {
                 "id": "id_singleton",
@@ -294,4 +312,4 @@ class TestSQLFileStore(unittest.TestCase):
         INSERT INTO myschema.type_a (entityid,entitytype,fiwareservicepath,recvtime,location,municipality,ref) VALUES
         ('id_singleton_5','type_A','/testsrv',NOW(),ST_GeomFromGeoJSON('{"type": "Point", "coordinates": [1, 2]}'),'NA',5);
         """
-        self.do_test(expected, "", entities=entities, replace_id=['id', 'ref'], subservice="/testsrv", schema="myschema")
+        self.do_test(expected, "", entities=entities, replace_id={'type_A':['id', 'ref']}, subservice="/testsrv", schema="myschema")


### PR DESCRIPTION
Actualmente el store `sqlFileStore` no puede usarse para generar un fichero SQL de carga de entidades *singleton* (tal como las define URBO-DEPLOYER, con `replaceId`), porque esas entidades necesitan que se sobrescriba el `id` de la entidad antes de guardar en base de datos.

Esta PR soluciona el problema añadiendo al `sqlFileStore` un parámetro opcional `replace_id` que simula el comportamiento de un flujo histórico configurado con un `replaceId`. El sqlFileStore genera un id de entidad a partir de los atributos especificados, antes de construir la orden SQL.