### PR TITLE
fix typing support

### DIFF
--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -53,5 +53,9 @@ setup(
     install_requires=INSTALL_REQUIRES,
     license=LICENSE,
     packages=find_packages(),
+    # See https://peps.python.org/pep-0561/
+    package_data={
+        'tc_etl_lib': ['py.typed']
+    },
     include_package_data=True
 )

--- a/python-lib/tc_etl_lib/tc_etl_lib/cb.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/cb.py
@@ -27,7 +27,7 @@ ContextBroker routines for Python:
 '''
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 from typing import Iterable, List, Any, Optional
 
 import logging
@@ -118,7 +118,7 @@ class cbManager:
         self.block_size = block_size
 
 
-    def delete_entities(self, *, service: str = None, subservice: str = None, auth: authManager = None, limit: int = 100, type: str = None, q: str = None, mq: str = None, georel: str = None, geometry: str = None, coords: str = None, id: str = None, options_get: list = [], options_send: list = []):
+    def delete_entities(self, *, service: Optional[str] = None, subservice: Optional[str] = None, auth: Optional[authManager] = None, limit: int = 100, type: Optional[str] = None, q: Optional[str] = None, mq: Optional[str] = None, georel: Optional[str] = None, geometry: Optional[str] = None, coords: Optional[str] = None, id: Optional[str] = None, options_get: list = [], options_send: list = []):
         """Delete data from context broker
 
         :param service: Define service from which entities are deleted, defaults to None
@@ -149,7 +149,7 @@ class cbManager:
 
         self.send_batch(service=service, subservice=subservice, auth=auth, entities=entities, actionType='delete', options=options_send)
 
-    def get_entities(self, *, service: str = None, subservice: str = None, auth: authManager = None, limit: int = 100, type: str = None, orderBy: str = None, q: str = None, mq: str = None, georel: str = None, geometry: str = None, coords: str = None, id: str = None, options: list = []):
+    def get_entities(self, *, service: Optional[str] = None, subservice: Optional[str] = None, auth: Optional[authManager] = None, limit: int = 100, type: Optional[str] = None, orderBy: Optional[str] = None, q: Optional[str] = None, mq: Optional[str] = None, georel: Optional[str] = None, geometry: Optional[str] = None, coords: Optional[str] = None, id: Optional[str] = None, options: list = []):
         """Retrieve data from context broker
 
         :param service: Define service from which entities are retrieved, defaults to None
@@ -265,7 +265,7 @@ class cbManager:
         return resp.json()
 
 
-    def send_batch(self, *, service:str = None, subservice: str = None, auth: authManager = None, entities: Iterable[Any], actionType: str = 'append', options: list = []) -> bool:
+    def send_batch(self, *, service: Optional[str] = None, subservice: Optional[str] = None, auth: Optional[authManager] = None, entities: Iterable[Any], actionType: str = 'append', options: list = []) -> bool:
         """Send batch data to context broker with block control
 
         :param auth: Define authManager
@@ -303,7 +303,7 @@ class cbManager:
 
         return True
 
-    def __send_batch(self, *, service:str = None, subservice: str = None, auth: authManager = None, entities: List[Any], actionType: str = 'append', options: list = []) -> bool:
+    def __send_batch(self, *, service: Optional[str] = None, subservice: Optional[str] = None, auth: Optional[authManager] = None, entities: List[Any], actionType: str = 'append', options: list = []) -> bool:
         """Send batch data to context broker
 
         :param auth: Define authManager
@@ -348,7 +348,7 @@ class cbManager:
 
         return True
 
-    def __batch_creation(self, *, service: str = None, subservice: str = None, auth: authManager = None, entities: List[Any], actionType: str = 'append', options: list = []):
+    def __batch_creation(self, *, service: Optional[str] = None, subservice: Optional[str] = None, auth: Optional[authManager] = None, entities: List[Any], actionType: str = 'append', options: list = []):
         """Send batch data to Context Broker
 
         :param entities: Entities data

--- a/python-lib/tc_etl_lib/tc_etl_lib/py.typed
+++ b/python-lib/tc_etl_lib/tc_etl_lib/py.typed
@@ -1,0 +1,2 @@
+# Marker file to support type hints in exported package
+# See https://peps.python.org/pep-0561/

--- a/python-lib/tc_etl_lib/tc_etl_lib/store.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/store.py
@@ -38,7 +38,7 @@ import psycopg2
 Store = Callable[[Iterable[Any]], None]
 
 @contextmanager
-def orionStore(cb: cbManager, auth: authManager, *, service:str=None, subservice:str=None, actionType:str='append', options:list=[]):
+def orionStore(cb: cbManager, auth: authManager, *, service: Optional[str]=None, subservice: Optional[str]=None, actionType:str='append', options:list=[]):
     '''
     Context manager that creates a store to save entities to the given cbManager
     All parameters are the same as for the cbManager.send_batch function
@@ -70,12 +70,12 @@ def sqlFileStore(path: Path, *, subservice:str, schema:str=":target_schema", nam
     mode = "a+" if append else "w+"
     handler = path.open(mode=mode, encoding="utf-8")
     some_table_names = table_names or {} # make sure it is not None
-    replace_id = replace_id or {} # make sure it is not None
+    some_replace_id = replace_id or {} # make sure it is not None
     try:
         def send_batch(entities: Iterable[Any]):
             """Send a batch of entities to the database"""
             for chunk in iter_chunk(entities, chunk_size):
-                handler.write(sqlfile_batch(schema=schema, namespace=namespace, table_names=some_table_names, subservice=subservice, replace_id=replace_id, entities=chunk))
+                handler.write(sqlfile_batch(schema=schema, namespace=namespace, table_names=some_table_names, subservice=subservice, replace_id=some_replace_id, entities=chunk))
                 handler.write("\n")
         yield send_batch
     finally:


### PR DESCRIPTION
Al intentar usar la librería tc-etl-lib desde otros proyectos, siempre tenemos problemas con los tipos. *mypy* se queja de que la librería no está tipada.

Por lo que parece, para exportar información de tipo en los paquetes de instalación de las librerías, hay que seguir unos pasos que están en la PEP 0561 (https://peps.python.org/pep-0561/)

Esta PR implementa la primera de las opciones descrita en la PEP (fichero `py.typed`). Adicionalmente, corrige todos los warnings que genera mypy al validar el código de la propia librería.