### PR TITLE
Update python12 prelanding

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.12]
 
     # FIXME: it would be great to use cache to avoid re-creating the virtualenv
     # and installing dependencies every time. We know the syphar/restore-virtualenv@v1 and
@@ -21,10 +24,10 @@ jobs:
     # dependencies are in requeriments.txt file (and in this case we have them in setup.py)
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install pytest tool
         run: pip install pytest==8.3.4
       - name: Install library dependencies

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -508,6 +508,8 @@ TOTAL                        403    221    45%
 
 ## Changelog
 
+- Add: support for Python 3.12 (keeping also compatibility with Python 3.8)
+
 0.13.0 (Jun 26th, 2024)
 
 - Fix: anchor numpy version to 1.24.4 (latest compatible with python 3.8 and pandas < 2.2.2) ([#89](https://github.com/telefonicasc/etl-framework/issues/89))

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -509,6 +509,8 @@ TOTAL                        403    221    45%
 ## Changelog
 
 - Add: support for Python 3.12 (keeping also compatibility with Python 3.8)
+- Fix: upgrade requests from 2.21.0 to 2.25.1 (for Python 3.8 case)
+- Fix: upgrade urllib3 from 1.24.1 to 1.26.16', (for Python 3.8 case)
 
 0.13.0 (Jun 26th, 2024)
 

--- a/python-lib/tc_etl_lib/README.md
+++ b/python-lib/tc_etl_lib/README.md
@@ -510,7 +510,7 @@ TOTAL                        403    221    45%
 
 - Add: support for Python 3.12 (keeping also compatibility with Python 3.8)
 - Fix: upgrade requests from 2.21.0 to 2.25.1 (for Python 3.8 case)
-- Fix: upgrade urllib3 from 1.24.1 to 1.26.16', (for Python 3.8 case)
+- Fix: upgrade urllib3 from 1.24.1 to 1.26.16 (for Python 3.8 case)
 
 0.13.0 (Jun 26th, 2024)
 

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -38,7 +38,7 @@ LONG_DESC_TYPE = "text/markdown"
 #Dos listas separadas (para Python >=3.12 y para Python <3.12)
 INSTALL_REQUIRES = [
     'requests==2.21.0',
-    'urllib3==1.24.1',
+    'urllib3==1.26.16',
     'psycopg2-binary>=2.9.5',
     'pandas==2.0.3',
     # Pandas < 2.2.2 requiere numpy < 2.0.0, ver https://pandas.pydata.org/docs/whatsnew/v2.2.2.html

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -66,7 +66,7 @@ setup(
     author_email=AUTHOR_EMAIL,
     url=URL,
     extras_require={
-        ':python_version<"3.12"': INSTALL_REQUIRES
+        ':python_version<"3.12"': INSTALL_REQUIRES,
         ':python_version>="3.12"': INSTALL_REQUIRES_PYTHON_3_12
     },
     license=LICENSE,

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -37,7 +37,7 @@ LONG_DESC_TYPE = "text/markdown"
 #Paquetes necesarios para que funcione la librería. Se instalarán a la vez si no lo tuvieras ya instalado
 #Dos listas separadas (para Python >=3.12 y para Python <3.12)
 INSTALL_REQUIRES = [
-    'requests==2.21.0',
+    'requests== 2.25.1',
     'urllib3==1.26.16',
     'psycopg2-binary>=2.9.5',
     'pandas==2.0.3',

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -37,7 +37,7 @@ LONG_DESC_TYPE = "text/markdown"
 #Paquetes necesarios para que funcione la librería. Se instalarán a la vez si no lo tuvieras ya instalado
 #Dos listas separadas (para Python >=3.12 y para Python <3.12)
 INSTALL_REQUIRES = [
-    'requests== 2.25.1',
+    'requests==2.25.1',
     'urllib3==1.26.16',
     'psycopg2-binary>=2.9.5',
     'pandas==2.0.3',

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -38,7 +38,7 @@ LONG_DESC_TYPE = "text/markdown"
 #Dos listas separadas (para Python >=3.12 y para Python <3.12)
 INSTALL_REQUIRES = [
     'requests==2.21.0',
-    'urllib3==1.26.0',
+    'urllib3==1.24.1',
     'psycopg2-binary>=2.9.5',
     'pandas==2.0.3',
     # Pandas < 2.2.2 requiere numpy < 2.0.0, ver https://pandas.pydata.org/docs/whatsnew/v2.2.2.html

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -35,7 +35,20 @@ LONG_DESCRIPTION = (HERE / "README.md").read_text(encoding='utf-8') #Referencia 
 LONG_DESC_TYPE = "text/markdown"
 
 #Paquetes necesarios para que funcione la librería. Se instalarán a la vez si no lo tuvieras ya instalado
+#Dos listas separadas (para Python >=3.12 y para Python <3.12)
 INSTALL_REQUIRES = [
+    'requests==2.21.0',
+    'urllib3==1.24.1',
+    'psycopg2-binary>=2.9.5',
+    'pandas==2.0.3',
+    # Pandas < 2.2.2 requiere numpy < 2.0.0, ver https://pandas.pydata.org/docs/whatsnew/v2.2.2.html
+    # Con pandas < 2.2.2 y numpy >= 2.0.0, se produce el error:
+    # ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
+    # La última release de numpy antes de 2.0.0 es 1.26.4.
+    # La última release de numpy compatible con python 3.8 es 1.24.4
+    'numpy==1.24.4'
+]
+INSTALL_REQUIRES_PYTHON_3_12 = [
     'requests==2.28.2',
     'urllib3==1.26.16',
     'psycopg2-binary>=2.9.5',
@@ -52,7 +65,10 @@ setup(
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
     url=URL,
-    install_requires=INSTALL_REQUIRES,
+    extras_require={
+        ':python_version<"3.12"': INSTALL_REQUIRES
+        ':python_version>="3.12"': INSTALL_REQUIRES_PYTHON_3_12
+    },
     license=LICENSE,
     packages=find_packages(),
     include_package_data=True

--- a/python-lib/tc_etl_lib/setup.py
+++ b/python-lib/tc_etl_lib/setup.py
@@ -38,7 +38,7 @@ LONG_DESC_TYPE = "text/markdown"
 #Dos listas separadas (para Python >=3.12 y para Python <3.12)
 INSTALL_REQUIRES = [
     'requests==2.21.0',
-    'urllib3==1.26.16',
+    'urllib3==1.26.0',
     'psycopg2-binary>=2.9.5',
     'pandas==2.0.3',
     # Pandas < 2.2.2 requiere numpy < 2.0.0, ver https://pandas.pydata.org/docs/whatsnew/v2.2.2.html

--- a/python-lib/tc_etl_lib/tc_etl_lib/cb.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/cb.py
@@ -403,7 +403,7 @@ class cbManager:
             read=self.post_retry_connect,
             backoff_factor=self.post_retry_backoff_factor,
             status_forcelist=(429, 500, 502, 503, 504),
-            method_whitelist=('HEAD', 'GET', 'OPTIONS', 'POST')
+            allowed_methods=('HEAD', 'GET', 'OPTIONS', 'POST')
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/python-lib/tc_etl_lib/tc_etl_lib/iota.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/iota.py
@@ -102,7 +102,7 @@ class iotaManager:
             read=self.post_retry_connect,
             backoff_factor=self.post_retry_backoff_factor,
             status_forcelist=(429, 500, 502, 503, 504),
-            method_whitelist=('HEAD', 'GET', 'OPTIONS', 'POST')
+            allowed_methods=('HEAD', 'GET', 'OPTIONS', 'POST')
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/python-lib/tc_etl_lib/tc_etl_lib/iota.py
+++ b/python-lib/tc_etl_lib/tc_etl_lib/iota.py
@@ -102,7 +102,7 @@ class iotaManager:
             read=self.post_retry_connect,
             backoff_factor=self.post_retry_backoff_factor,
             status_forcelist=(429, 500, 502, 503, 504),
-            allowed_methods=('HEAD', 'GET', 'OPTIONS', 'POST')
+            method_whitelist=('HEAD', 'GET', 'OPTIONS', 'POST')
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
Continuación de PR https://github.com/telefonicasc/etl-framework/pull/95

A su creación (al punto de commit 66ee4dd501de1527bb49b5ff97152a9e05fc1af9) esta PR es indéntica en lo contenido a la anterior.

A partir de ahí, evolucionará para completar los siguientes puntos:

- [x] Soporte dual en Python 3.8 y 3.12
- [x] Check que el paquete contruido es válido en ambos casos
- [x] Revisar en la documentación en markdown referencias versión de Python y ajustar
- [x] Changelog

CC: @MiguelAngelVLCI @xavi12p